### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,6 @@ Client library to interact with Universal Core's `unicore.hub`
     :target: https://coveralls.io/r/universalcore/unicore.hub.client?branch=develop
     :alt: Code Coverage
 
-.. image:: https://pypip.in/version/unicore.hub.client/badge.svg
+.. image:: https://img.shields.io/pypi/v/unicore.hub.client.svg
     :target: https://pypi.python.org/pypi/unicore.hub.client
     :alt: Pypi Package


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20unicore-hub-client))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `unicore-hub-client`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.